### PR TITLE
implement skip:true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export default function npm ( options ) {
 				id += `/${parts.shift()}`;
 			}
 
-			if ( ~skip.indexOf(id) ) return null;
+			if ( skip !== true && ~skip.indexOf( id ) ) return null;
 
 			// disregard entry module
 			if ( !importer ) return null;
@@ -35,23 +35,25 @@ export default function npm ( options ) {
 					{
 						basedir: dirname( importer ),
 						packageFilter ( pkg ) {
-							const id = pkg[ 'name' ];
 							if ( options.jsnext ) {
 								const main = pkg[ 'jsnext:main' ];
 								if ( main ) {
 									pkg[ 'main' ] = main;
 								} else if ( !useMain ) {
-									reject( Error( `Package ${id} (imported by ${importer}) does not have a jsnext:main field. You should either allow legacy modules with options.main, or skip it with options.skip = ['${id}'])` ) );
+									if ( skip === true ) accept( false );
+									else reject( Error( `Package ${importee} (imported by ${importer}) does not have a jsnext:main field. You should either allow legacy modules with options.main, or skip it with options.skip = ['${importee}'])` ) );
 								}
 							} else if ( !useMain ) {
-								reject( Error( `To import from a package in node_modules (${id}), either options.jsnext or options.main must be true` ) );
+								if ( skip === true ) accept( false );
+								else reject( Error( `To import from a package in node_modules (${importee}), either options.jsnext or options.main must be true` ) );
 							}
 							return pkg;
 						}
 					},
 					( err, resolved ) => {
 						if ( err ) {
-							reject( err );
+							if ( skip === true ) accept( false );
+							else reject( err );
 						} else {
 							if ( resolved === COMMONJS_BROWSER_EMPTY ) resolved = ES6_BROWSER_EMPTY;
 							if ( ~builtins.indexOf( resolved ) ) resolved = null;

--- a/test/node_modules/jsnext/entry.js
+++ b/test/node_modules/jsnext/entry.js
@@ -1,0 +1,1 @@
+export default 'JSNEXT';

--- a/test/node_modules/jsnext/package.json
+++ b/test/node_modules/jsnext/package.json
@@ -1,0 +1,3 @@
+{
+	"jsnext:main": "entry.js"
+}

--- a/test/node_modules/legacy/entry.js
+++ b/test/node_modules/legacy/entry.js
@@ -1,0 +1,1 @@
+export default 'LEGACY';

--- a/test/node_modules/legacy/package.json
+++ b/test/node_modules/legacy/package.json
@@ -1,0 +1,3 @@
+{
+	"main": "entry.js"
+}

--- a/test/samples/skip-true/main.js
+++ b/test/samples/skip-true/main.js
@@ -1,0 +1,7 @@
+import jsnext from 'jsnext';
+import legacy from 'legacy';
+import missing from 'missing';
+
+console.log( jsnext );
+console.log( legacy );
+console.log( missing );

--- a/test/test.js
+++ b/test/test.js
@@ -210,4 +210,34 @@ describe( 'rollup-plugin-npm', function () {
 			assert.deepEqual( bundle.imports, [ '@scoped/foo' ]);
 		});
 	});
+
+	it( 'skip: true allows all unfound non-jsnext:main dependencies to be skipped without error', () => {
+		return rollup.rollup({
+			entry: 'samples/skip-true/main.js',
+			plugins: [
+				npm({
+					jsnext: true,
+					main: false,
+					skip: true
+				})
+			]
+		}).then( bundle => {
+			assert.deepEqual( bundle.imports, [ 'legacy', 'missing' ]);
+		});
+	});
+
+	it( 'skip: true allows all unfound dependencies to be skipped without error', () => {
+		return rollup.rollup({
+			entry: 'samples/skip-true/main.js',
+			plugins: [
+				npm({
+					jsnext: false,
+					main: false,
+					skip: true
+				})
+			]
+		}).then( bundle => {
+			assert.deepEqual( bundle.imports, [ 'jsnext', 'legacy', 'missing' ]);
+		});
+	});
 });


### PR DESCRIPTION
With this option, the plugin will allow dependencies that can't be found (or that don't meet the criteria, i.e. `jsnext:main`) to be treated as external, rather than erroring. Fixes #6 